### PR TITLE
Create sample threejs viewer

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# sample 3d assets to test with the threejs viewer
+/sample_3d_assets

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "react-dom": "^18.0.0",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
+        "three": "^0.139.2",
         "web-vitals": "^2.1.4"
       }
     },
@@ -14676,6 +14677,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
+    "node_modules/three": {
+      "version": "0.139.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.139.2.tgz",
+      "integrity": "sha512-gV7q7QY8rogu7HLFZR9cWnOQAUedUhu2WXAnpr2kdXZP9YDKsG/0ychwQvWkZN5PlNw9mv5MoCTin6zNTXoONg=="
+    },
     "node_modules/throat": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
@@ -26356,6 +26362,11 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+    },
+    "three": {
+      "version": "0.139.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.139.2.tgz",
+      "integrity": "sha512-gV7q7QY8rogu7HLFZR9cWnOQAUedUhu2WXAnpr2kdXZP9YDKsG/0ychwQvWkZN5PlNw9mv5MoCTin6zNTXoONg=="
     },
     "throat": {
       "version": "6.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
+    "three": "^0.139.2",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -35,7 +35,7 @@ function App() {
             <Route
               path="/"
               element={
-                <Map storymapsLink="https://story.maps.arcgis.com/apps/StorytellingSwipe/index.html?appid=459ff1719f5f427180cd8b793894052b" />
+                <Map storymapsLink="https://storymaps.arcgis.com/stories/d67072087566491d8c544f9df151b328" />
               }
             />
             <Route path="/about" element={<About text="about text" />} />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,6 +2,7 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import { BrowserRouter, Link, Routes, Route } from "react-router-dom";
 import Map from "./pages/map";
 import About from "./pages/about";
+import ThreeJsViewer from "./pages/threejsviewer";
 
 function App() {
   return (
@@ -23,6 +24,11 @@ function App() {
                   About
                 </Link>
               </li>
+              <li className="nav-item">
+                <Link to="/threejs" className="nav-link">
+                  Threejs Sample
+                </Link>
+              </li>
             </div>
           </nav>
           <Routes>
@@ -33,6 +39,7 @@ function App() {
               }
             />
             <Route path="/about" element={<About text="about text" />} />
+            <Route path="/threejs" element={<ThreeJsViewer />} />
           </Routes>
         </div>
       </BrowserRouter>

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,15 +1,11 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import './index.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "./index.css";
+import App from "./App";
+import reportWebVitals from "./reportWebVitals";
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(<App />);
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))

--- a/frontend/src/pages/threejsviewer.js
+++ b/frontend/src/pages/threejsviewer.js
@@ -1,10 +1,9 @@
-import React, { useEffect } from "react";
+import React from "react";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader";
 import { MTLLoader } from "three/examples/jsm/loaders/MTLLoader";
 
-// TODO: use this instead of hardcoding the height value as 600
 const style = {
   height: 600, // we can control scene size by setting container dimensions
 };
@@ -17,20 +16,20 @@ class ThreeJsViewer extends React.Component {
     this.doRender();
     this.doControls();
     this.addLights();
-    window.addEventListener("resize", this.handleWindowResize);
+    this.setEventListeners();
     this.animate();
   }
 
   componentWillUnmount() {
     window.removeEventListener("resize", this.handleWindowResize);
     window.cancelAnimationFrame(this.requestID);
-    // this.controls.dispose();
+    this.controls.dispose();
   }
 
   setCamera = () => {
     this.camera = new THREE.PerspectiveCamera(
       45,
-      this.mount.clientWidth / 600,
+      this.mount.clientWidth / this.mount.clientHeight,
       1,
       1000
     );
@@ -59,11 +58,11 @@ class ThreeJsViewer extends React.Component {
     this.renderer = new THREE.WebGLRenderer();
     this.renderer.setPixelRatio(window.devicePixelRatio);
     this.renderer.setClearColor(new THREE.Color("hsl(0, 0%, 10%)"));
-
-    this.renderer.setSize(this.mount.clientWidth, 600);
+    this.renderer.setSize(this.mount.clientWidth, this.mount.clientHeight);
     this.mount.appendChild(this.renderer.domElement); // mount using React ref
   };
 
+  // add ability to drag camera POV around
   doControls = () => {
     this.controls = new OrbitControls(this.camera, this.renderer.domElement);
     this.controls.enableDamping = true;
@@ -90,8 +89,20 @@ class ThreeJsViewer extends React.Component {
     this.scene.add(lights[2]);
   };
 
-  setEvents = () => {
-    // nothing yet
+  setEventListeners = () => {
+    window.addEventListener("resize", this.handleWindowResize);
+  };
+
+  handleWindowResize = () => {
+    const width = this.mount.clientWidth;
+    const height = this.mount.clientHeight;
+
+    this.renderer.setSize(width, height);
+    this.camera.aspect = width / height;
+
+    // Note that after making changes to most of camera properties you have to call
+    // .updateProjectionMatrix for the changes to take effect.
+    this.camera.updateProjectionMatrix();
   };
 
   animate = () => {

--- a/frontend/src/pages/threejsviewer.js
+++ b/frontend/src/pages/threejsviewer.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+function ThreeJsViewer() {
+  return <h1>Sample 3JS viewer</h1>;
+}
+
+export default ThreeJsViewer;

--- a/frontend/src/pages/threejsviewer.js
+++ b/frontend/src/pages/threejsviewer.js
@@ -1,7 +1,108 @@
-import React from "react";
+import React, { useEffect } from "react";
+import * as THREE from "three";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
+import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader";
+import { MTLLoader } from "three/examples/jsm/loaders/MTLLoader";
 
-function ThreeJsViewer() {
-  return <h1>Sample 3JS viewer</h1>;
+// TODO: use this instead of hardcoding the height value as 600
+const style = {
+  height: 600, // we can control scene size by setting container dimensions
+};
+
+class ThreeJsViewer extends React.Component {
+  componentDidMount() {
+    this.setCamera();
+    this.setScene();
+    this.loadModel();
+    this.doRender();
+    this.doControls();
+    this.addLights();
+    window.addEventListener("resize", this.handleWindowResize);
+    this.animate();
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("resize", this.handleWindowResize);
+    window.cancelAnimationFrame(this.requestID);
+    // this.controls.dispose();
+  }
+
+  setCamera = () => {
+    this.camera = new THREE.PerspectiveCamera(
+      45,
+      this.mount.clientWidth / 600,
+      1,
+      1000
+    );
+    this.camera.position.z = 9;
+  };
+
+  setScene = () => {
+    this.scene = new THREE.Scene();
+    this.ambient = new THREE.AmbientLight(0xffffff, 1.0);
+    this.scene.add(this.ambient);
+  };
+
+  loadModel = () => {
+    var mtlLoader = new MTLLoader();
+    mtlLoader.load("sample_3d_assets/3d_model.mtl", (materials) => {
+      materials.preload();
+      var objLoader = new OBJLoader();
+      objLoader.setMaterials(materials);
+      objLoader.load("sample_3d_assets/3d_model.obj", (object) => {
+        this.scene.add(object);
+      });
+    });
+  };
+
+  doRender = () => {
+    this.renderer = new THREE.WebGLRenderer();
+    this.renderer.setPixelRatio(window.devicePixelRatio);
+    this.renderer.setClearColor(new THREE.Color("hsl(0, 0%, 10%)"));
+
+    this.renderer.setSize(this.mount.clientWidth, 600);
+    this.mount.appendChild(this.renderer.domElement); // mount using React ref
+  };
+
+  doControls = () => {
+    this.controls = new OrbitControls(this.camera, this.renderer.domElement);
+    this.controls.enableDamping = true;
+    this.controls.dampingFactor = 0.25;
+    this.controls.enableZoom = true;
+  };
+
+  // adding some lights to the scene
+  addLights = () => {
+    const lights = [];
+
+    // set color and intensity of lights
+    lights[0] = new THREE.PointLight(0xffffff, 1, 0);
+    lights[1] = new THREE.PointLight(0xffffff, 1, 0);
+    lights[2] = new THREE.PointLight(0xffffff, 1, 0);
+
+    // place some lights around the scene for best looks and feel
+    lights[0].position.set(0, 2000, 0);
+    lights[1].position.set(1000, 2000, 1000);
+    lights[2].position.set(-1000, -2000, -1000);
+
+    this.scene.add(lights[0]);
+    this.scene.add(lights[1]);
+    this.scene.add(lights[2]);
+  };
+
+  setEvents = () => {
+    // nothing yet
+  };
+
+  animate = () => {
+    this.renderer.render(this.scene, this.camera);
+    this.requestID = window.requestAnimationFrame(this.animate);
+    this.controls.update();
+  };
+
+  render() {
+    return <div style={style} ref={(ref) => (this.mount = ref)} />;
+  }
 }
 
 export default ThreeJsViewer;


### PR DESCRIPTION
This PR creates a new page on the TRADE website which allows for the viewing of a sample 3d object using the three.js library. Image can be dragged and zoomed in on.

Screenshot: 
![image](https://user-images.githubusercontent.com/43192580/164103587-76abe3ed-0f17-43e0-bdbb-3143e2aaf411.png)
